### PR TITLE
Valid xml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source "https://rubygems.org"
+gem "builder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,10 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  builder

--- a/parsesb.rb
+++ b/parsesb.rb
@@ -135,13 +135,9 @@ def render_pro5_arrangement(xml, song, verse_uuids)
   xml.arrangements :containerClass => "NSMutableArray" do
     xml.RVSongArrangement :name => "typical", :uuid => "#{new_uuid}", :color => "0 0 0 0", "serialization-array-index" => "0" do
       xml.groupIDs :containerClass => "NSMutableArray" do
-        song[:order].each.with_index do |verse_name, i|
-          begin
-            verse_uuid = verse_uuids.fetch(verse_name)
-            xml.NSMutableString "serialization-native-value" => "#{verse_uuid}",  "serialization-array-index" => "#{i}"
-          rescue KeyError => e
-            puts "[warning] skipping #{verse_name.inspect}: #{e}"
-          end
+        verses = song[:order].map { |verse_name| verse_uuids.fetch(verse_name, nil) }
+        verses.compact.each.with_index do |verse_uuid, i|
+          xml.NSMutableString "serialization-native-value" => "#{verse_uuid}",  "serialization-array-index" => "#{i}"
         end
       end
     end

--- a/parsesb.rb
+++ b/parsesb.rb
@@ -1,6 +1,7 @@
 require "yaml"
 
 def main(*files)
+  xml_errors = 0
   files.each do |file|
     begin
       parsed = parse(file)
@@ -21,7 +22,9 @@ def main(*files)
             File.open(pro5, 'w') do |f|
               render_pro5(f, song)
             end
-            system "xmllint", pro5, :out => "/dev/null"
+            unless system "xmllint", pro5, :out => "/dev/null"
+              xml_errors += 1
+            end
           end
         end
       else
@@ -31,6 +34,9 @@ def main(*files)
       puts "#{file}: #{e}"
       puts e.backtrace.take(5)
     end
+  end
+  if xml_errors > 1
+    puts "#{xml_errors} files were produced with invalid XML!"
   end
 end
 

--- a/parsesb.rb
+++ b/parsesb.rb
@@ -53,7 +53,7 @@ def render_pro5(io, song)
   year, publisher = split_copyright(song["copyright"])
   xml = Builder::XmlMarkup.new :target => io
   xml.instruct!
-  xml.RVPresentationDocument :height => 600, :width => 800, :versionNumber => 500, :docType => 0, :creatorCode => 1349676880, :lastDateUsed => time(Time.now), :usedCount => 0, :category => "Song", :resourcesDirectory => "", :backgroundColors => "0 0 0 1", :drawingBackgroundColor => "0", :notes => song[:keywords].join(" "), :artist => song["artist"], :author => song["artist"], :album => "", :CCLIDisplay => "1", :CCLIArtistCredits => "", :CCLISongTitle => song["title"], :CCLIPublisher => publisher, :CCLICopyrightInfo => year, :CCLILicenseNumber => song["ccli#"], :chordChartPath => "" do
+  xml.RVPresentationDocument :height => 768, :width => 1024, :versionNumber => 500, :docType => 0, :creatorCode => 1349676880, :lastDateUsed => time(Time.now), :usedCount => 0, :category => "Song", :resourcesDirectory => "", :backgroundColors => "0 0 0 1", :drawingBackgroundColor => "0", :notes => song[:keywords].join(" "), :artist => song["artist"], :author => song["artist"], :album => "", :CCLIDisplay => "1", :CCLIArtistCredits => "", :CCLISongTitle => song["title"], :CCLIPublisher => publisher, :CCLICopyrightInfo => year, :CCLILicenseNumber => song["ccli#"], :chordChartPath => "" do
     xml.tag! "_-RVProTransitionObject-_transitionObject", :transitionType => "0", :transitionDuration => "1", :motionEnabled => "0", :motionDuration => "20", :motionSpeed => "100"
     verse_uuids = Hash.new { |h,k| h[k] = new_uuid }
     render_pro5_verses(xml, song, verse_uuids)

--- a/parsesb.rb
+++ b/parsesb.rb
@@ -21,6 +21,7 @@ def main(*files)
             File.open(pro5, 'w') do |f|
               render_pro5(f, song)
             end
+            system "xmllint", pro5, :out => "/dev/null"
           end
         end
       else

--- a/parsesb.rb
+++ b/parsesb.rb
@@ -53,7 +53,7 @@ def render_pro5(io, song)
   year, publisher = split_copyright(song["copyright"])
   xml = Builder::XmlMarkup.new :target => io
   xml.instruct!
-  xml.RVPresentationDocument :height => 768, :width => 1024, :versionNumber => 500, :docType => 0, :creatorCode => 1349676880, :lastDateUsed => time(Time.now), :usedCount => 0, :category => "Song", :resourcesDirectory => "", :backgroundColors => "0 0 0 1", :drawingBackgroundColor => "0", :notes => song[:keywords].join(" "), :artist => song["artist"], :author => song["artist"], :album => "", :CCLIDisplay => "1", :CCLIArtistCredits => "", :CCLISongTitle => song["title"], :CCLIPublisher => publisher, :CCLICopyrightInfo => year, :CCLILicenseNumber => song["ccli#"], :chordChartPath => "" do
+  xml.RVPresentationDocument :height => 600, :width => 800, :versionNumber => 500, :docType => 0, :creatorCode => 1349676880, :lastDateUsed => time(Time.now), :usedCount => 0, :category => "Song", :resourcesDirectory => "", :backgroundColors => "0 0 0 1", :drawingBackgroundColor => "0", :notes => song[:keywords].join(" "), :artist => song["artist"], :author => song["artist"], :album => "", :CCLIDisplay => "1", :CCLIArtistCredits => "", :CCLISongTitle => song["title"], :CCLIPublisher => publisher, :CCLICopyrightInfo => year, :CCLILicenseNumber => song["ccli#"], :chordChartPath => "" do
     xml.tag! "_-RVProTransitionObject-_transitionObject", :transitionType => "0", :transitionDuration => "1", :motionEnabled => "0", :motionDuration => "20", :motionSpeed => "100"
     verse_uuids = Hash.new { |h,k| h[k] = new_uuid }
     render_pro5_verses(xml, song, verse_uuids)


### PR DESCRIPTION
ProPresenter was choking on some of the converted files. This branch clears up most/all of the errors:
- the output sometimes included invalid XML. This branch introduces the builder gem to fix.
- the output sometimes produced a serialized `NSMutableArray` with non-sequential indices (e.g. 0, 2, 3, 5, 7). This branch makes them sequential.
- our displays are 800x600 (ick), so ProPresenter was generating a warning on every song that the resolution was wrong.
